### PR TITLE
Replace Python server with Rust-based actix-web server

### DIFF
--- a/CLAUDE_CONTEXT.md
+++ b/CLAUDE_CONTEXT.md
@@ -45,6 +45,8 @@ src/
 - **rayon**: Multithreading
 - **wasm-bindgen**: Web deployment
 - **web-sys**: WebGPU API bindings
+- **actix-web** 4.4: Rust-based web server for WASM deployment
+- **actix-files** 0.6: Static file serving
 
 ## Performance Features
 - Spatial partitioning (QuadTree/Grid)
@@ -66,8 +68,10 @@ src/
 ✅ **BOTH DESKTOP AND WASM BUILDS WORKING**
 
 ## File Status
-- `Cargo.toml`: Dependencies configured for desktop + web
-- `wasm-build.sh`: Web build script with HTML/JS wrapper
+- `Cargo.toml`: Dependencies configured for desktop + web + actix-web server
+- `wasm-build.sh`: Web build script with HTML/JS wrapper (updated for Rust server)
+- `src/bin/server.rs`: Actix-web server for serving WASM build
+- `serve.sh`: Convenience script for starting the web server
 - `examples/`: Basic simulation + custom forces demos
 - `presets/`: JSON configs for classic_particle_life, gravity_system
 - `www/`: Web deployment assets
@@ -92,6 +96,13 @@ src/
 - Generated complete WASM package (2.2MB .wasm + JS bindings)
 - Full browser support with interactive controls
 
+**Web Server:** ✅ RUST-BASED ACTIX-WEB
+- Replaced Python SimpleHTTPServer with actix-web
+- Configurable HOST/PORT via environment variables
+- Proper CORS headers for WebAssembly
+- Binds to 0.0.0.0 by default for network accessibility
+- Default port 3000 (configurable)
+
 Both builds now compile and run successfully!
 
 ## Next Development Areas (if continuing)
@@ -108,9 +119,13 @@ Both builds now compile and run successfully!
 # Desktop
 cargo run --release
 
-# Web
+# Web - Build WASM
 ./wasm-build.sh
-cd www && python3 serve.py
+
+# Web - Serve with Rust server (port 3000)
+cargo run --bin server
+# Or use convenience script:
+./serve.sh
 
 # Test
 cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 nannou = "0.19"
+actix-web = "4.4"
+actix-files = "0.6"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+env_logger = "0.10"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 nannou = { version = "0.19", features = ["wasm-experimental"] }

--- a/serve.sh
+++ b/serve.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Set default values
+HOST="${HOST:-0.0.0.0}"
+PORT="${PORT:-3000}"
+
+echo "Starting Rust-based web server..."
+echo "Serving WASM build from ./www directory"
+echo ""
+echo "Configuration:"
+echo "  HOST=$HOST (set HOST env var to change)"
+echo "  PORT=$PORT (set PORT env var to change)"
+echo ""
+echo "Examples:"
+echo "  PORT=8080 ./serve.sh    # Run on port 8080"
+echo "  HOST=127.0.0.1 ./serve.sh    # Bind to localhost only"
+echo ""
+
+# Export for cargo to use
+export HOST
+export PORT
+
+cargo run --bin server

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,0 +1,44 @@
+use actix_files as fs;
+use actix_web::{middleware, web, App, HttpResponse, HttpServer};
+use std::env;
+
+async fn index() -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("text/html")
+        .body(include_str!("../../www/index.html"))
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+    
+    // Get host and port from environment variables with defaults
+    let host = env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+    let port: u16 = env::var("PORT")
+        .unwrap_or_else(|_| "3000".to_string())
+        .parse()
+        .expect("PORT must be a valid number");
+    
+    println!("Starting server at http://{}:{}", host, port);
+    println!("Serving files from ./www directory");
+    println!("Press Ctrl+C to stop the server");
+    println!();
+    println!("Environment variables:");
+    println!("  HOST={} (default: 0.0.0.0)", host);
+    println!("  PORT={} (default: 3000)", port);
+
+    HttpServer::new(|| {
+        App::new()
+            .wrap(middleware::Logger::default())
+            .wrap(
+                middleware::DefaultHeaders::new()
+                    .add(("Cross-Origin-Embedder-Policy", "require-corp"))
+                    .add(("Cross-Origin-Opener-Policy", "same-origin")),
+            )
+            .route("/", web::get().to(index))
+            .service(fs::Files::new("/", "./www").index_file("index.html"))
+    })
+    .bind((host.as_str(), port))?
+    .run()
+    .await
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,29 @@
+use actix_files as fs;
+use actix_web::{middleware, web, App, HttpResponse, HttpServer};
+
+async fn index() -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type("text/html")
+        .body(include_str!("../www/index.html"))
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    println!("Starting server at http://localhost:3000");
+    println!("Press Ctrl+C to stop the server");
+
+    HttpServer::new(|| {
+        App::new()
+            .wrap(middleware::Logger::default())
+            .wrap(
+                middleware::DefaultHeaders::new()
+                    .header("Cross-Origin-Embedder-Policy", "require-corp")
+                    .header("Cross-Origin-Opener-Policy", "same-origin"),
+            )
+            .route("/", web::get().to(index))
+            .service(fs::Files::new("/", "./www").index_file("index.html"))
+    })
+    .bind(("127.0.0.1", 3000))?
+    .run()
+    .await
+}

--- a/wasm-build.sh
+++ b/wasm-build.sh
@@ -267,44 +267,15 @@ if [ ! -f www/index.html ]; then
 EOF
 fi
 
-# Create a simple HTTP server script
-cat > www/serve.py << 'EOF'
-#!/usr/bin/env python3
-import http.server
-import socketserver
-import os
-import sys
-
-PORT = 8000
-
-class CORSRequestHandler(http.server.SimpleHTTPRequestHandler):
-    def end_headers(self):
-        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
-        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
-        super().end_headers()
-
-if __name__ == "__main__":
-    os.chdir(os.path.dirname(os.path.abspath(__file__)))
-    
-    if len(sys.argv) > 1:
-        PORT = int(sys.argv[1])
-    
-    with socketserver.TCPServer(("", PORT), CORSRequestHandler) as httpd:
-        print(f"Server starting at http://localhost:{PORT}")
-        print("Press Ctrl+C to stop the server")
-        try:
-            httpd.serve_forever()
-        except KeyboardInterrupt:
-            print("\nServer stopped")
-EOF
-
-chmod +x www/serve.py
-
 echo "✅ WebAssembly build complete!"
 echo ""
 echo "To run the web version:"
-echo "  cd www && python3 serve.py"
-echo "  Then open http://localhost:8000 in your browser"
+echo "  cargo run --bin server"
+echo "  Then open http://localhost:3000 in your browser"
+echo ""
+echo "Or use the convenience script:"
+echo "  ./serve.sh"
+echo "  Then open http://localhost:3000 in your browser"
 echo ""
 echo "Note: Make sure your browser supports WebAssembly and SharedArrayBuffer"
 echo "      Chrome/Firefox with --enable-features=SharedArrayBuffer flag might be needed"


### PR DESCRIPTION
## Summary
- Replaced Python SimpleHTTPServer with a Rust-based actix-web server
- Added environment variable support for flexible deployment
- Improved server configuration for better network accessibility

## Changes
- **New actix-web server** (`src/bin/server.rs`):
  - Serves WASM build on configurable port (default 3000)
  - Binds to 0.0.0.0 by default for network accessibility
  - Supports HOST and PORT environment variables
  - Includes proper CORS headers for WebAssembly

- **Updated build infrastructure**:
  - Added actix-web dependencies to Cargo.toml
  - Updated wasm-build.sh to reference new Rust server
  - Created serve.sh convenience script
  - Updated CLAUDE_CONTEXT.md documentation

## Benefits
- **Fully Rust-based stack**: No Python dependency for serving
- **Better performance**: actix-web is highly performant
- **Flexible deployment**: Environment variable configuration
- **Network ready**: Binds to all interfaces by default

## Test Plan
- [x] Server starts successfully on port 3000
- [x] Environment variables (HOST/PORT) work correctly
- [x] WASM files are served with correct headers
- [x] Browser can load and run the application
- [x] Server handles requests from external IPs

## Usage
```bash
# Default (port 3000)
cargo run --bin server

# Custom port
PORT=8080 cargo run --bin server

# Using convenience script
./serve.sh
```

🤖 Generated with [Claude Code](https://claude.ai/code)