### PR TITLE
Fix WASM loading issues and improve error handling

### DIFF
--- a/CLAUDE_CONTEXT.md
+++ b/CLAUDE_CONTEXT.md
@@ -71,10 +71,13 @@ src/
 - `Cargo.toml`: Dependencies configured for desktop + web + actix-web server
 - `wasm-build.sh`: Web build script with HTML/JS wrapper (updated for Rust server)
 - `src/bin/server.rs`: Actix-web server for serving WASM build
+- `src/wasm.rs`: WASM bindings with console logging for debugging
 - `serve.sh`: Convenience script for starting the web server
+- `www/index.html`: Main web interface with improved error handling
+- `www/test.html`: WASM functionality test page
+- `www/dist/`: Generated WASM files (inochi.js, inochi_bg.wasm)
 - `examples/`: Basic simulation + custom forces demos
 - `presets/`: JSON configs for classic_particle_life, gravity_system
-- `www/`: Web deployment assets
 - Documentation: README.md, API.md (comprehensive)
 
 ## Current State
@@ -88,13 +91,16 @@ src/
 - Fixed borrow checker issues
 - nannou 0.19 + wgpu 0.19 working perfectly
 
-**WASM Build:** ✅ WORKING  
+**WASM Build:** ✅ COMPILING & LOADING
 - Reduced from 200 compilation errors to 0
 - Enabled nannou's `wasm-experimental` feature
 - Fixed WebGPU API compatibility (web-sys features)
 - Added wasm-bindgen-futures support
 - Generated complete WASM package (2.2MB .wasm + JS bindings)
-- Full browser support with interactive controls
+- WASM module loads successfully in browser
+- Console logging implemented for debugging
+- Test page available at `/test.html` for verification
+- **Note:** Particle rendering not yet visible (needs canvas binding work)
 
 **Web Server:** ✅ RUST-BASED ACTIX-WEB
 - Replaced Python SimpleHTTPServer with actix-web
@@ -105,7 +111,19 @@ src/
 
 Both builds now compile and run successfully!
 
-## Next Development Areas (if continuing)
+## Current Issues
+- **WASM Canvas Binding:** Particles not yet rendering in browser
+  - WASM module loads but nannou canvas integration incomplete
+  - Need to properly bind WebGL/WebGPU context to HTML canvas
+  - Render loop needs to be connected to browser animation frame
+
+## Next Development Areas
+**Immediate Priority:**
+- Complete nannou WASM canvas binding for particle rendering
+- Connect render loop to requestAnimationFrame
+- Implement proper WebGL/WebGPU context initialization
+
+**Future Enhancements:**
 - GPU compute shaders for >10k particles
 - Advanced shading (PBR, bloom, HDR)
 - Mobile/touch optimization

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,7 +1,17 @@
 use wasm_bindgen::prelude::*;
-use nannou::prelude::*;
 use crate::{App, config::Preset};
 use std::sync::Mutex;
+
+// Console logging for WASM
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
+macro_rules! console_log {
+    ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
+}
 
 // Global state for the WebAssembly version
 static mut GLOBAL_APP: Option<Mutex<App>> = None;
@@ -9,12 +19,25 @@ static mut GLOBAL_APP: Option<Mutex<App>> = None;
 #[wasm_bindgen(start)]
 pub fn wasm_main() {
     console_error_panic_hook::set_once();
+    console_log!("WASM module initialized");
 }
 
 #[wasm_bindgen]
 pub async fn start_simulation() -> Result<(), JsValue> {
-    // In WASM mode, nannou apps are started differently
-    nannou::app(model).run();
+    console_log!("Starting simulation in WASM mode...");
+    
+    // For now, just create a simple test to verify WASM is working
+    // The full nannou integration needs more complex setup
+    unsafe {
+        if GLOBAL_APP.is_none() {
+            // Create a dummy app for testing
+            console_log!("Creating application instance...");
+            // Note: This is a simplified version for testing
+            // Full nannou WASM integration would require proper canvas binding
+            console_log!("Application ready (test mode)");
+        }
+    }
+    
     Ok(())
 }
 
@@ -76,23 +99,13 @@ pub fn get_fps() -> f32 {
     0.0
 }
 
-fn model(app: &nannou::App) -> App {
-    // In WASM mode, create a simple window without the build() method
-    // The window creation is handled differently in nannou WASM
-    let window_id = app.main_window().id();
-    App::new(app, window_id)
-}
+// Note: Full nannou WASM integration would require a proper model function
+// This is commented out for now as we're doing a simpler test
+// fn model(app: &nannou::App) -> App {
+//     let window_id = app.main_window().id();
+//     App::new(app, window_id)
+// }
 
-// Export types for TypeScript
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(js_namespace = console)]
-    fn log(s: &str);
-}
-
-macro_rules! console_log {
-    ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
-}
 
 #[wasm_bindgen]
 pub struct WasmParticle {

--- a/www/index.html
+++ b/www/index.html
@@ -117,12 +117,24 @@
         let isPaused = false;
 
         async function run() {
+            console.log('Starting WASM initialization...');
             try {
-                // Initialize the WebAssembly module
-                await init();
+                // Add more detailed logging
+                console.log('Loading WASM module from ./dist/inochi_bg.wasm');
+                
+                // Explicitly pass the WASM file path to init
+                await init('./dist/inochi_bg.wasm');
+                console.log('WASM module initialized successfully');
+                
+                // Check if functions are available
+                if (typeof start_simulation !== 'function') {
+                    throw new Error('start_simulation function not found in WASM exports');
+                }
                 
                 // Start the simulation
+                console.log('Starting simulation...');
                 await start_simulation();
+                console.log('Simulation started successfully');
                 
                 isInitialized = true;
                 document.getElementById('loading').style.display = 'none';
@@ -133,9 +145,14 @@
                 
             } catch (error) {
                 console.error('Failed to initialize:', error);
+                console.error('Error stack:', error.stack);
                 document.getElementById('loading').style.display = 'none';
                 document.getElementById('error').style.display = 'block';
-                document.getElementById('error').textContent = `Error: ${error.message}`;
+                document.getElementById('error').innerHTML = `
+                    <strong>Error loading WebAssembly module:</strong><br>
+                    ${error.message}<br>
+                    <small>Check browser console for more details</small>
+                `;
             }
         }
 
@@ -209,8 +226,22 @@
             }
         });
 
-        // Start the application
-        run();
+        // Check WebAssembly support
+        if (typeof WebAssembly === 'undefined') {
+            console.error('WebAssembly is not supported in this browser');
+            document.getElementById('loading').style.display = 'none';
+            document.getElementById('error').style.display = 'block';
+            document.getElementById('error').innerHTML = `
+                <strong>WebAssembly Not Supported</strong><br>
+                This application requires WebAssembly support.<br>
+                Please use a modern browser like Chrome, Firefox, Safari, or Edge.
+            `;
+        } else {
+            console.log('WebAssembly is supported');
+            console.log('Browser:', navigator.userAgent);
+            // Start the application
+            run();
+        }
     </script>
 </body>
 </html>

--- a/www/test.html
+++ b/www/test.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>WASM Test</title>
+</head>
+<body>
+    <h1>WASM Loading Test</h1>
+    <div id="status">Loading...</div>
+    <div id="result"></div>
+    
+    <script type="module">
+        async function test() {
+            const statusEl = document.getElementById('status');
+            const resultEl = document.getElementById('result');
+            
+            try {
+                statusEl.textContent = 'Importing module...';
+                const module = await import('./dist/inochi.js');
+                
+                statusEl.textContent = 'Initializing WASM...';
+                await module.default('./dist/inochi_bg.wasm');
+                
+                statusEl.textContent = 'WASM loaded! Testing functions...';
+                
+                // Test basic functions
+                const results = [];
+                
+                if (typeof module.start_simulation === 'function') {
+                    results.push('✅ start_simulation found');
+                    try {
+                        await module.start_simulation();
+                        results.push('✅ start_simulation called successfully');
+                    } catch (e) {
+                        results.push(`❌ start_simulation error: ${e.message}`);
+                    }
+                }
+                
+                if (typeof module.get_particle_count === 'function') {
+                    results.push('✅ get_particle_count found');
+                    const count = module.get_particle_count();
+                    results.push(`✅ Particle count: ${count}`);
+                }
+                
+                if (typeof module.get_fps === 'function') {
+                    results.push('✅ get_fps found');
+                    const fps = module.get_fps();
+                    results.push(`✅ FPS: ${fps}`);
+                }
+                
+                resultEl.innerHTML = results.join('<br>');
+                statusEl.textContent = 'Test complete!';
+                
+            } catch (error) {
+                statusEl.textContent = 'Error!';
+                resultEl.innerHTML = `<span style="color: red">Error: ${error.message}<br>Stack: ${error.stack}</span>`;
+                console.error('Test failed:', error);
+            }
+        }
+        
+        test();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Fixed WebAssembly module loading issues
- Added comprehensive error handling and debugging
- Created test page for WASM functionality verification

## Problem
The WASM module was not loading correctly, showing only "Loading WebAssembly module..." without any error messages or progress indication. This was particularly problematic on mobile browsers where developer tools are not readily available.

## Solution
1. **Explicit WASM path**: Pass the WASM file path explicitly to the `init()` function
2. **Console logging**: Added detailed console.log statements throughout the loading process
3. **Error handling**: Improved error messages with more descriptive text
4. **Browser compatibility**: Added WebAssembly support detection
5. **Test page**: Created `/test.html` for isolated WASM testing
6. **Simplified initialization**: Temporarily simplified the `start_simulation` function for testing

## Changes
- Modified `www/index.html`:
  - Added explicit WASM file path to init call
  - Added comprehensive console logging
  - Added WebAssembly support detection
  - Improved error display with HTML formatting

- Modified `src/wasm.rs`:
  - Added console_log macro for debugging
  - Simplified start_simulation for initial testing
  - Added logging at key points

- Added `www/test.html`:
  - Standalone test page for WASM functionality
  - Tests individual WASM exports
  - Provides clear success/failure indicators

## Test Plan
- [x] WASM module compiles successfully
- [x] Console logging works in browser
- [x] Error messages display properly
- [x] Test page loads and runs tests
- [ ] Full simulation starts (requires further nannou WASM integration)

## Next Steps
The full nannou WASM integration requires additional work to properly bind the canvas and handle the render loop. This PR provides the foundation for debugging and iterating on that integration.

## Testing URLs
- Main app: `http://localhost:3000/`
- Test page: `http://localhost:3000/test.html`

🤖 Generated with [Claude Code](https://claude.ai/code)